### PR TITLE
Remove line continuation

### DIFF
--- a/lib/vagrant_utm/scripts/add_port_forwards.applescript
+++ b/lib/vagrant_utm/scripts/add_port_forwards.applescript
@@ -25,11 +25,7 @@ on run argv
     set ruleComponents to text items of ruleArg
     
     -- Create a port forwarding rule record
-    set portForwardRule to { Â
-          indexVal:indexNumber, protocolVal:item 1 of ruleComponents, Â
-          guestAddress:item 2 of ruleComponents, guestPort:item 3 of ruleComponents, Â
-          hostAddress:item 4 of ruleComponents, hostPort:item 5 of ruleComponents Â
-        }
+    set portForwardRule to { indexVal:indexNumber, protocolVal:item 1 of ruleComponents, guestAddress:item 2 of ruleComponents, guestPort:item 3 of ruleComponents, hostAddress:item 4 of ruleComponents, hostPort:item 5 of ruleComponents }
     
     -- Add the rule to the list
     set end of portForwardRules to portForwardRule
@@ -49,13 +45,7 @@ on run argv
           set portForwards to port forwards of anInterface
           
           -- Create a new port forward configuration
-          set newPortForward to { Â
-                protocol:(protocolVal of portForwardRule), Â
-                guest address:(guestAddress of portForwardRule), Â 
-                guest port:(guestPort of portForwardRule), Â
-                host address:(hostAddress of portForwardRule), Â
-                host port:(hostPort of portForwardRule) Â
-              }
+          set newPortForward to { protocol:(protocolVal of portForwardRule), guest address:(guestAddress of portForwardRule), guest port:(guestPort of portForwardRule), host address:(hostAddress of portForwardRule), host port:(hostPort of portForwardRule) }
           
           -- Add new port forward to the list
           copy newPortForward to the end of portForwards

--- a/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
+++ b/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
@@ -17,9 +17,7 @@ on run argv
                     set i to i + 1
                     # Log the port forward details Virtualbox style 
                     # 'Forwarding(nicIndex)(ruleIndex)="protocol,guestAddress,guestPort,hostAddress,hostPort"'
-                    log "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & "," Â
-                        & guest address of aPortForward & "," & guest port of aPortForward & "," Â
-                        & host address of aPortForward & "," & host port of aPortForward & "\""
+                    log "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & "," & guest address of aPortForward & "," & guest port of aPortForward & "," & host address of aPortForward & "," & host port of aPortForward & "\""
                 end repeat
             end if
         end repeat


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e4965e9d-18b1-4350-b497-132f0652e89b)

I’m not an AppleScript expert, but based on the screenshot (which is in Korean), the error translates to "unknown token" in English.
It seems to be caused by a line continuation encoding issue.
This PR removes line continuation to resolve the problem.