### PR TITLE
Fix the line continuation character

### DIFF
--- a/lib/vagrant_utm/scripts/add_port_forwards.applescript
+++ b/lib/vagrant_utm/scripts/add_port_forwards.applescript
@@ -25,10 +25,10 @@ on run argv
     set ruleComponents to text items of ruleArg
     
     -- Create a port forwarding rule record
-    set portForwardRule to { Â
-          indexVal:indexNumber, protocolVal:item 1 of ruleComponents, Â
-          guestAddress:item 2 of ruleComponents, guestPort:item 3 of ruleComponents, Â
-          hostAddress:item 4 of ruleComponents, hostPort:item 5 of ruleComponents Â
+    set portForwardRule to { Â¬
+          indexVal:indexNumber, protocolVal:item 1 of ruleComponents, Â¬
+          guestAddress:item 2 of ruleComponents, guestPort:item 3 of ruleComponents, Â¬
+          hostAddress:item 4 of ruleComponents, hostPort:item 5 of ruleComponents Â¬
         }
     
     -- Add the rule to the list
@@ -49,12 +49,12 @@ on run argv
           set portForwards to port forwards of anInterface
           
           -- Create a new port forward configuration
-          set newPortForward to { Â
-                protocol:(protocolVal of portForwardRule), Â
-                guest address:(guestAddress of portForwardRule), Â 
-                guest port:(guestPort of portForwardRule), Â
-                host address:(hostAddress of portForwardRule), Â
-                host port:(hostPort of portForwardRule) Â
+          set newPortForward to { Â¬
+                protocol:(protocolVal of portForwardRule), Â¬
+                guest address:(guestAddress of portForwardRule), Â¬
+                guest port:(guestPort of portForwardRule), Â¬
+                host address:(hostAddress of portForwardRule), Â¬
+                host port:(hostPort of portForwardRule) Â¬
               }
           
           -- Add new port forward to the list

--- a/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
+++ b/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
@@ -17,8 +17,8 @@ on run argv
                     set i to i + 1
                     # Log the port forward details Virtualbox style 
                     # 'Forwarding(nicIndex)(ruleIndex)="protocol,guestAddress,guestPort,hostAddress,hostPort"'
-                    log "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & "," Â
-                        & guest address of aPortForward & "," & guest port of aPortForward & "," Â
+                    log "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & "," Â¬
+                        & guest address of aPortForward & "," & guest port of aPortForward & "," Â¬
                         & host address of aPortForward & "," & host port of aPortForward & "\""
                 end repeat
             end if


### PR DESCRIPTION
I have the same problem as #18 in my Japanese environment. The line continuation character in AppleScript is U+00AC ("¬", Not Sign), and its UTF-8 encoding is a 2-byte string `c2 ac` in hex. But the scripts in this project use a 1-byte string `c2`, which cannot be recognized as the line continuation character, at least in my environment. So, this PR replaces every occurrence of `c2` with `c2 ac`, solving the problem.