### PR TITLE
Add support for Apple Virtualization VMs with VirtioFS and mDNS SSH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.21"
   gem "vagrant", git: "https://github.com/hashicorp/vagrant.git", tag: "v2.4.1"
+  gem "vagrant-spec", git: "https://github.com/hashicorp/vagrant-spec.git"
 end
 
 group :plugins do

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,31 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+begin
+  require "bundler/gem_tasks"
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
 
-RSpec::Core::RakeTask.new(:spec)
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
 
-require "rubocop/rake_task"
+  task default: %i[spec rubocop]
+rescue LoadError
+  # Allow rake to work without full dev dependencies
+end
 
-RuboCop::RakeTask.new
+namespace :test do
+  desc "Run unit tests"
+  task :unit do
+    sh "bundle exec rspec spec/"
+  end
 
-task default: %i[spec rubocop]
+  desc "Run acceptance tests (requires macOS + UTM + macOS box)"
+  task :acceptance do
+    sh "bundle exec rspec test/acceptance/"
+  end
+
+  desc "Run macOS acceptance tests (shell script)"
+  task :macos do
+    sh "test/acceptance/macos/run.sh"
+  end
+end

--- a/lib/vagrant_utm/action.rb
+++ b/lib/vagrant_utm/action.rb
@@ -43,6 +43,7 @@ module VagrantPlugins
       autoload :PrepareNFSSettings, action_root.join("prepare_nfs_settings")
       autoload :PrepareNFSValidIds, action_root.join("prepare_nfs_valid_ids")
       autoload :PrepareForwardedPortCollisionParams, action_root.join("prepare_forwarded_port_collision_params")
+      autoload :PromptVirtioFS, action_root.join("prompt_virtiofs")
       autoload :Resume, action_root.join("resume")
       autoload :SetId, action_root.join("set_id")
       autoload :SetName, action_root.join("set_name")
@@ -75,6 +76,7 @@ module VagrantPlugins
           b.use ForwardPorts
           b.use SetHostname
           b.use Customize, "pre-boot"
+          b.use PromptVirtioFS
           b.use Boot
           b.use Customize, "post-boot"
 

--- a/lib/vagrant_utm/action/prompt_virtiofs.rb
+++ b/lib/vagrant_utm/action/prompt_virtiofs.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module VagrantPlugins
+  module Utm
+    module Action
+      # Prompts user to manually configure VirtioFS shared folders in UTM GUI
+      # for Apple Virtualization VMs. This is required because macOS security-scoped
+      # bookmarks cannot be created programmatically.
+      class PromptVirtioFS
+        include Vagrant::Action::Builtin::MixinSyncedFolders
+
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+
+          # Only prompt for Apple Virtualization VMs with synced folders
+          folders = get_synced_folders(machine, env)
+          if apple_vm?(machine) && folders.any?
+            prompt_for_virtiofs(machine, env, folders)
+          end
+
+          @app.call(env)
+        end
+
+        private
+
+        def apple_vm?(machine)
+          machine.provider_config.skip_directory_share_mode
+        end
+
+        def get_synced_folders(machine, env)
+          opts = {
+            cached: !env[:synced_folders_cached].nil?,
+            config: env[:synced_folders_config],
+            disable_usable_check: !env[:test].nil?
+          }
+          all_folders = synced_folders(machine, **opts)
+
+          # Collect non-disabled folder paths
+          paths = []
+          all_folders.each do |_type, type_folders|
+            type_folders.each do |_id, data|
+              next if data[:disabled]
+
+              hostpath = File.expand_path(data[:hostpath], machine.env.root_path)
+              paths << { hostpath: hostpath, guestpath: data[:guestpath] }
+            end
+          end
+          paths
+        rescue StandardError
+          []
+        end
+
+        def prompt_for_virtiofs(machine, env, folders)
+          ui = env[:ui]
+          vm_name = machine.provider.driver.read_vm_name rescue nil
+          vm_name ||= machine.name.to_s
+
+          ui.warn("")
+          ui.warn("=" * 70)
+          ui.warn("  MANUAL STEP REQUIRED: VirtioFS Shared Folders")
+          ui.warn("=" * 70)
+          ui.warn("")
+          ui.warn("Apple Virtualization VMs require manual shared folder setup.")
+          ui.warn("macOS security restrictions prevent automated configuration.")
+          ui.warn("")
+          ui.warn("Please complete these steps in UTM:")
+          ui.warn("")
+          ui.warn("  1. Open UTM application")
+          ui.warn("  2. Right-click '#{vm_name}' -> Edit")
+          ui.warn("  3. Go to 'Sharing' tab")
+          ui.warn("  4. Remove existing entries (if any), then re-add these paths:")
+          ui.warn("")
+          folders.each do |folder|
+            ui.warn("     -> #{folder[:hostpath]}")
+            ui.warn("        (mounts at: /Volumes/My Shared Files/#{File.basename(folder[:hostpath])}/)")
+          end
+          ui.warn("")
+          ui.warn("  5. Save the VM settings")
+          ui.warn("")
+          ui.warn("=" * 70)
+          ui.warn("")
+          ui.ask("Press ENTER when done to continue booting the VM...")
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant_utm/config.rb
+++ b/lib/vagrant_utm/config.rb
@@ -36,6 +36,12 @@ module VagrantPlugins
       # @return [Integer]
       attr_accessor :wait_time
 
+      # If true, skips auto-setting directory_share_mode to 'virtFS'.
+      # Set this to true for Apple Virtualization VMs which don't use QEMU directory sharing.
+      #
+      # @return [Boolean]
+      attr_accessor :skip_directory_share_mode
+
       # Initialize the configuration with unset values.
       def initialize
         super
@@ -128,9 +134,8 @@ module VagrantPlugins
       def finalize!
         # By default, we check for guest additions (qemu-ga)
         @check_guest_additions = true if @check_guest_additions == UNSET_VALUE
-        # Always set the directory share mode to 'virtFS'
-        # default share folder implementation in utm plugin
-        self.directory_share_mode = "virtFS"
+        # Set virtFS as default for QEMU VMs, skip for Apple Virtualization
+        self.directory_share_mode = "virtFS" unless @skip_directory_share_mode
         # By default, we assume the VM supports virtio 9p filesystems
         @functional_9pfs = true if @functional_9pfs == UNSET_VALUE
         # The default name is just nothing, and we default it

--- a/lib/vagrant_utm/driver/version_4_5.rb
+++ b/lib/vagrant_utm/driver/version_4_5.rb
@@ -176,6 +176,15 @@ module VagrantPlugins
         def read_guest_ip
           output = execute("ip-address", @uuid)
           output.strip.split("\n")
+        rescue Errors::UtmctlError => e
+          # Apple Virtualization VMs don't support ip-address command
+          # Return empty array so callers can handle gracefully
+          if e.message.include?("Operation not supported by the backend")
+            @logger.warn("ip-address not supported (Apple Virtualization VM), returning empty")
+            []
+          else
+            raise
+          end
         end
 
         def read_network_interfaces

--- a/lib/vagrant_utm/driver/version_4_6.rb
+++ b/lib/vagrant_utm/driver/version_4_6.rb
@@ -17,9 +17,11 @@ module VagrantPlugins
         def clear_shared_folders
           # Get the list of shared folders
           shared_folders = read_shared_folders
+          return if shared_folders.nil? || shared_folders.empty?
+
           # Get the args to remove the shared folders
           script_path = @script_path.join("read_shared_folders_args.js")
-          cmd = ["osascript", script_path.to_s, @uuid, "--ids", shared_folders.join(",")]
+          cmd = ["osascript", "-l", "JavaScript", script_path.to_s, @uuid, "--ids", shared_folders.join(",")]
           output = execute_shell(*cmd)
           result = JSON.parse(output)
           return unless result["status"]
@@ -59,7 +61,7 @@ module VagrantPlugins
         def read_shared_folders
           @logger.debug("Reading shared folders")
           script_path = @script_path.join("read_shared_folders.js")
-          cmd = ["osascript", script_path.to_s, @uuid]
+          cmd = ["osascript", "-l", "JavaScript", script_path.to_s, @uuid]
           output = execute_shell(*cmd)
           result = JSON.parse(output)
           return unless result["status"]
@@ -88,10 +90,10 @@ module VagrantPlugins
         end
 
         def unshare_folders(folders)
-          @logger.debug("Unsharing folder: #{folder[:name]}")
+          @logger.debug("Unsharing folders: #{folders}")
           # Get the args to remove the shared folders
           script_path = @script_path.join("read_shared_folders_args.js")
-          cmd = ["osascript", script_path.to_s, @uuid, "--ids", folders.join(",")]
+          cmd = ["osascript", "-l", "JavaScript", script_path.to_s, @uuid, "--ids", folders.join(",")]
           output = execute_shell(*cmd)
           result = JSON.parse(output)
           return unless result["status"]

--- a/lib/vagrant_utm/synced_folder.rb
+++ b/lib/vagrant_utm/synced_folder.rb
@@ -17,13 +17,39 @@ module VagrantPlugins
       # This is called before VM Boot to prepare the synced folders.
       # Add required configs to the VM.
       def prepare(machine, folders, _opts)
-        share_folders(machine, folders)
+        # Skip if no folders to share
+        return if folders.empty?
+
+        # For Apple Virtualization VMs, skip automated setup - it doesn't work
+        # because macOS security-scoped bookmarks cannot be created programmatically.
+        # The PromptVirtioFS action will prompt user to add folders via UTM GUI.
+        return if apple_vm?(machine)
+
+        # For QEMU VMs, configure 9pfs sharing
+        begin
+          share_folders(machine, folders)
+        rescue StandardError => e
+          machine.ui.warn("Could not configure shared folders: #{e.message}")
+        end
       end
 
       # This is called after VM Boot to mount the synced folders.
       # Mount the shared folders inside the VM.
       def enable(machine, folders, _opts) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/PerceivedComplexity
+        # For Apple Virtualization, VirtioFS auto-mounts at /Volumes/My Shared Files/
+        # User configures shared folders manually via UTM GUI (prompted before boot)
+        if apple_vm?(machine)
+          machine.ui.info("VirtioFS shared folders auto-mount at /Volumes/My Shared Files/")
+          return
+        end
+
+        # For QEMU VMs, configure and mount via 9pfs
         share_folders(machine, folders)
+
+        # Check if guest supports mounting
+        unless machine.guest.capability?(:mount_virtualbox_shared_folder)
+          return
+        end
 
         # sort guestpaths first, so we don't step on ourselves
         folders = folders.sort_by do |_id, data|
@@ -101,6 +127,11 @@ module VagrantPlugins
 
       def os_friendly_id(id)
         id.gsub(%r{[\s/\\]}, "_").sub(/^_/, "")
+      end
+
+      # Check if this is an Apple Virtualization VM (opt-in via config)
+      def apple_vm?(machine)
+        machine.provider_config.skip_directory_share_mode
       end
 
       # share_folders sets up the shared folder definitions on the

--- a/test/acceptance/base.rb
+++ b/test/acceptance/base.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "vagrant-spec/acceptance"
+require_relative "shared/context_utm"

--- a/test/acceptance/macos/Vagrantfile
+++ b/test/acceptance/macos/Vagrantfile
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+# frozen_string_literal: true
+
+# Apple Virtualization macOS VMs use shared networking (bridged-like)
+# No NAT port forwarding - SSH directly to mDNS hostname
+
+# Derive paths from synced folder source
+HOST_PATH = File.expand_path(".")
+FOLDER_NAME = File.basename(HOST_PATH)
+GUEST_PATH = HOST_PATH.sub(%r{^/Users/[^/]+}, "/Users/vagrant")
+VIRTFS_MOUNT = "/Volumes/My Shared Files/#{FOLDER_NAME}"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = ENV["MACOS_BOX"] || "macOS26"
+  config.vm.box_url = ENV["MACOS_BOX_URL"] if ENV["MACOS_BOX_URL"]
+
+  # Direct SSH to VM (no port forwarding for Apple Virtualization)
+  config.ssh.host = ENV["MACOS_SSH_HOST"] || "vagrant-macos.local"
+  config.ssh.port = 22
+  config.ssh.username = "vagrant"
+  config.ssh.insert_key = false
+
+  # Disable default SSH port forwarding
+  config.vm.network "forwarded_port", id: "ssh", guest: 22, host: 2222, disabled: true
+
+  # VirtioFS synced folder - user will be prompted to add via UTM GUI
+  # Mounts at /Volumes/My Shared Files/<folder_name>/
+  config.vm.synced_folder ".", "/vagrant"
+
+  config.vm.provider :utm do |utm|
+    utm.memory = 4096
+    utm.cpus = 2
+    utm.check_guest_additions = false
+    # Apple Virtualization: skip QEMU directory_share_mode (uses VirtioFS instead)
+    utm.skip_directory_share_mode = true
+  end
+
+  # Create symlink to mirror host path structure under vagrant user's home
+  config.vm.provision "shell", inline: <<~SHELL
+    mkdir -p "#{File.dirname(GUEST_PATH)}"
+    ln -sfn "#{VIRTFS_MOUNT}" "#{GUEST_PATH}"
+  SHELL
+end

--- a/test/acceptance/macos/run.sh
+++ b/test/acceptance/macos/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+GUEST_PATH="/Users/vagrant/${PWD#/Users/*/}"
+
+echo "==> Starting VM..."
+vagrant up --provider=utm
+
+echo "==> Verifying SSH..."
+vagrant ssh -c 'uname -a'
+
+echo "==> Verifying Homebrew..."
+vagrant ssh -c 'brew --version'
+
+echo "==> Verifying symlinked path..."
+vagrant ssh -c "test -f ${GUEST_PATH}/Vagrantfile"
+
+echo "==> Verifying bidirectional sync..."
+rm -f README.md
+vagrant ssh -c "echo '# Test' > ${GUEST_PATH}/README.md"
+test -f README.md
+rm -f README.md
+
+echo "==> ALL TESTS PASSED"
+
+vagrant destroy -f

--- a/test/acceptance/provider/macos_spec.rb
+++ b/test/acceptance/provider/macos_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+describe "provider/utm/macos", component: "provider/utm" do
+  include_context "acceptance"
+  include_context "provider-utm"
+
+  before(:all) do
+    environment.skeleton("macos")
+  end
+
+  after(:all) do
+    # execute("vagrant", "destroy", "-f")
+  end
+
+  describe "vagrant up" do
+    it "boots the VM" do
+      result = execute("vagrant", "up", "--provider=utm")
+      expect(result.exit_code).to eq(0)
+    end
+  end
+
+  describe "ssh" do
+    it "connects successfully" do
+      result = execute("vagrant", "ssh", "-c", "uname -a")
+      expect(result.exit_code).to eq(0)
+      expect(result.stdout).to include("Darwin")
+    end
+  end
+
+  describe "homebrew" do
+    it "is installed" do
+      result = execute("vagrant", "ssh", "-c", "brew --version")
+      expect(result.exit_code).to eq(0)
+      expect(result.stdout).to match(/Homebrew \d+/)
+    end
+  end
+
+  describe "synced folder" do
+    it "mounts at symlinked path" do
+      result = execute("vagrant", "ssh", "-c", "test -f #{guest_path}/Vagrantfile")
+      expect(result.exit_code).to eq(0)
+    end
+
+    it "syncs bidirectionally" do
+      readme = File.join(environment.workdir, "README.md")
+      FileUtils.rm_f(readme)
+
+      execute("vagrant", "ssh", "-c", "echo '# Test' > #{guest_path}/README.md")
+
+      expect(File.exist?(readme)).to be(true)
+      FileUtils.rm_f(readme)
+    end
+  end
+end

--- a/test/acceptance/shared/context_utm.rb
+++ b/test/acceptance/shared/context_utm.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+shared_context "provider-utm" do
+  let(:provider) { "utm" }
+
+  let(:guest_path) do
+    "/Users/vagrant/#{environment.workdir.to_s.sub(%r{^/Users/[^/]+/}, "")}"
+  end
+
+  let(:skeleton_path) do
+    Pathname.new(File.expand_path("../skeletons", __dir__))
+  end
+end

--- a/test/acceptance/skeletons/macos/Vagrantfile
+++ b/test/acceptance/skeletons/macos/Vagrantfile
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+# frozen_string_literal: true
+
+# Apple Virtualization macOS VMs use shared networking (bridged-like)
+# No NAT port forwarding - SSH directly to mDNS hostname
+
+# Derive paths from synced folder source
+HOST_PATH = File.expand_path(".")
+FOLDER_NAME = File.basename(HOST_PATH)
+GUEST_PATH = HOST_PATH.sub(%r{^/Users/[^/]+}, "/Users/vagrant")
+VIRTFS_MOUNT = "/Volumes/My Shared Files/#{FOLDER_NAME}"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = ENV["MACOS_BOX"] || "macOS26"
+  config.vm.box_url = ENV["MACOS_BOX_URL"] if ENV["MACOS_BOX_URL"]
+
+  # Direct SSH to VM (no port forwarding for Apple Virtualization)
+  config.ssh.host = ENV["MACOS_SSH_HOST"] || "vagrant-macos.local"
+  config.ssh.port = 22
+  config.ssh.username = "vagrant"
+  config.ssh.insert_key = false
+
+  # Disable default SSH port forwarding
+  config.vm.network "forwarded_port", id: "ssh", guest: 22, host: 2222, disabled: true
+
+  # VirtioFS synced folder - user will be prompted to add via UTM GUI
+  # Mounts at /Volumes/My Shared Files/<folder_name>/
+  config.vm.synced_folder ".", "/vagrant"
+
+  config.vm.provider :utm do |utm|
+    utm.memory = 4096
+    utm.cpus = 2
+    utm.check_guest_additions = false
+    # Apple Virtualization: skip QEMU directory_share_mode (uses VirtioFS instead)
+    utm.skip_directory_share_mode = true
+  end
+
+  # Create symlink to mirror host path structure under vagrant user's home
+  config.vm.provision "shell", inline: <<~SHELL
+    mkdir -p "#{File.dirname(GUEST_PATH)}"
+    ln -sfn "#{VIRTFS_MOUNT}" "#{GUEST_PATH}"
+  SHELL
+end

--- a/vagrantfile_examples/macOS/README.md
+++ b/vagrantfile_examples/macOS/README.md
@@ -1,0 +1,242 @@
+# Creating a macOS Vagrant Box for UTM
+
+Until [UTM Packer support](https://github.com/utmapp/UTM/pull/7125) is merged, boxes must be created manually.
+
+## 1. Create a macOS VM in UTM
+
+> We're using the latest macOS to avoid downloading an IPSW. If you need a specific version, download it from [ipsw.me](https://ipsw.me/product/Mac).
+
+1. Open UTM and click **Create a New Virtual Machine**
+2. Select **Virtualize** (not Emulate)
+3. Choose **macOS 12+**
+4. Skip IPSW selection — UTM will use your host's macOS version
+5. Allocate resources:
+   - RAM: 8GB+ recommended
+   - CPU: 4+ cores recommended
+6. Set storage size (64GB+ recommended)
+7. Review and save
+8. Click play to start the VM
+9. Complete macOS setup wizard
+
+## 2. Configure Guest for Vagrant
+
+Boot the VM and complete the following steps inside the guest macOS.
+
+### Create vagrant user
+
+1. Open **System Settings** > **Users & Groups**
+2. Create new user:
+   - Username: `vagrant`
+   - Password: `vagrant`
+   - Account type: Administrator
+
+### Enable Remote Login (SSH)
+
+1. Open **System Settings** > **General** > **Sharing**
+2. Enable **Remote Login**
+3. Allow access for user `vagrant`
+
+### Configure passwordless sudo
+
+```bash
+sudo visudo
+```
+
+Add this line at the end:
+
+```
+vagrant ALL=(ALL) NOPASSWD: ALL
+```
+
+### Add Vagrant SSH key
+
+```bash
+mkdir -p /Users/vagrant/.ssh
+curl -L https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub \
+  >> /Users/vagrant/.ssh/authorized_keys
+chmod 700 /Users/vagrant/.ssh
+chmod 600 /Users/vagrant/.ssh/authorized_keys
+chown -R vagrant:staff /Users/vagrant/.ssh
+```
+
+### Install Homebrew
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### (Optional) Install common tools
+
+```bash
+brew install git curl wget
+```
+
+### Shut down the VM
+
+```bash
+sudo shutdown -h now
+```
+
+## 3. Create Vagrant Box
+
+### Locate VM files
+
+UTM stores VMs at:
+
+```
+~/Library/Containers/com.utmapp.UTM/Data/Documents/
+```
+
+Or for non-sandboxed UTM:
+
+```
+~/Documents/UTM/
+```
+
+Find your VM's `.utm` bundle (e.g., `macOS-Sequoia.utm`).
+
+### Create box
+
+```bash
+BOX_NAME="macOS26"
+VM_NAME="macOS 26"  # Name as shown in UTM
+UTM_DIR="$HOME/Library/Containers/com.utmapp.UTM/Data/Documents"
+
+# Create metadata.json
+echo '{"provider":"utm"}' > /tmp/metadata.json
+
+# Create box archive
+tar cvzf ~/$BOX_NAME.box \
+  -C /tmp metadata.json \
+  -C "$UTM_DIR" "$VM_NAME.utm"
+
+rm /tmp/metadata.json
+```
+
+### Add box to Vagrant
+
+```bash
+vagrant box add ~/$BOX_NAME.box --name $BOX_NAME
+```
+
+Verify:
+
+```bash
+vagrant box list
+# Boxes are stored in ~/.vagrant.d/boxes/
+```
+
+## 4. Use the Box
+
+### Apple Virtualization Limitations
+
+macOS VMs on Apple Silicon use the Apple Virtualization framework, which has different capabilities than QEMU VMs:
+
+| Feature | QEMU VMs | Apple Virtualization |
+|---------|----------|---------------------|
+| NAT Port Forwarding | ✅ | ❌ |
+| 9pfs/VirtFS | ✅ | ❌ |
+| qemu-guest-agent | ✅ | ❌ |
+| NFS (requires IP) | ✅ | ❌ |
+| VirtioFS | ❌ | ✅ (via UTM GUI) |
+| SSH | Port forward | mDNS hostname |
+
+### Create Vagrantfile
+
+```ruby
+# -*- mode: ruby -*-
+# frozen_string_literal: true
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "macOS26"
+
+  # Direct SSH via mDNS (Apple Virtualization uses shared networking)
+  config.ssh.host = "vagrant-macos.local"
+  config.ssh.port = 22
+  config.ssh.username = "vagrant"
+  config.ssh.insert_key = false
+
+  # Disable default SSH port forwarding (not supported)
+  config.vm.network "forwarded_port", id: "ssh", guest: 22, host: 2222, disabled: true
+
+  # Disable synced folders - use VirtioFS via UTM GUI instead
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :utm do |utm|
+    utm.memory = 8192
+    utm.cpus = 4
+    utm.check_guest_additions = false
+    utm.functional_9pfs = false
+  end
+end
+```
+
+### Start the VM
+
+```bash
+vagrant up --provider=utm
+```
+
+### Connect via SSH
+
+```bash
+vagrant ssh
+# Or directly: ssh vagrant@vagrant-macos.local
+```
+
+### Stop and destroy
+
+```bash
+vagrant halt
+vagrant destroy
+```
+
+## Shared Folders (VirtioFS)
+
+Apple Virtualization supports VirtioFS for shared folders, but configuration must be done through UTM GUI:
+
+1. Stop the VM
+2. Open VM settings in UTM
+3. Go to **Sharing**
+4. Add a shared directory
+5. Start the VM
+6. In macOS guest, shared folders appear at `/Volumes/My Shared Files/`
+
+See: https://docs.getutm.app/guest-support/macos/#virtiofs
+
+## Naming Convention
+
+Examples:
+- `macOS26` (macOS 26 / Tahoe)
+- `macOS15` (macOS 15 / Sequoia)
+- `macOS14` (macOS 14 / Sonoma)
+
+## Troubleshooting
+
+### SSH connection refused
+
+- Verify Remote Login is enabled in guest
+- Check vagrant user has SSH access
+- Confirm authorized_keys file has correct permissions
+- Ensure mDNS is working: `ping vagrant-macos.local`
+
+### mDNS hostname not resolving
+
+- macOS guest hostname should match (check with `hostname` in guest)
+- Both host and guest must be on same network
+- Try: `dns-sd -B _ssh._tcp` to browse for SSH services
+
+### VM won't start
+
+- Ensure UTM is installed and running
+- Check VM bundle wasn't corrupted during copy
+- Verify enough disk space for VM
+
+### "Operation not supported by the backend" error
+
+This happens when using features not supported by Apple Virtualization:
+- Port forwarding
+- 9pfs synced folders
+- IP address queries
+
+Use the Vagrantfile above which disables unsupported features.

--- a/vagrantfile_examples/macOS/Vagrantfile
+++ b/vagrantfile_examples/macOS/Vagrantfile
@@ -1,0 +1,35 @@
+# -*- mode: ruby -*-
+# frozen_string_literal: true
+
+# macOS on Apple Silicon uses Apple Virtualization framework in UTM
+# This has different capabilities than QEMU VMs:
+# - No NAT port forwarding (uses shared networking)
+# - VirtioFS for shared folders (auto-mounts at /Volumes/My Shared Files/)
+# - No qemu-guest-agent (can't query IP address)
+# - SSH via mDNS hostname (e.g., vagrant-macos.local)
+
+Vagrant.configure("2") do |config|
+  config.vm.box = ENV["MACOS_BOX"] || "macOS26"
+  config.vm.box_url = ENV["MACOS_BOX_URL"] if ENV["MACOS_BOX_URL"]
+
+  # Direct SSH to VM via mDNS (Apple Virtualization uses shared networking)
+  config.ssh.host = ENV["MACOS_SSH_HOST"] || "vagrant-macos.local"
+  config.ssh.port = 22
+  config.ssh.username = "vagrant"
+  config.ssh.insert_key = false
+
+  # Disable default SSH port forwarding (not supported by Apple Virtualization)
+  config.vm.network "forwarded_port", id: "ssh", guest: 22, host: 2222, disabled: true
+
+  # Synced folder via VirtioFS (Apple Virtualization)
+  # Auto-mounts at /Volumes/My Shared Files/ in macOS guest
+  config.vm.synced_folder ".", "/vagrant", type: :utm
+
+  config.vm.provider :utm do |utm|
+    utm.memory = 8192
+    utm.cpus = 4
+    utm.check_guest_additions = false
+    # Apple Virtualization: skip QEMU directory_share_mode (uses VirtioFS instead)
+    utm.skip_directory_share_mode = true
+  end
+end


### PR DESCRIPTION
# Description
Due to missing api integrations there is no way to run MacOS as a guest (at least I was not able to do it).
I've made some fixes and added a workaround for adding shared volumes manually.
I've also added an acceptance test.

This test needs a local `macOS26` box with the following:
_(I wish I could attach a `packer.hcl` file, but due to the same limitations it doesn't seem to be possible yet)_
1. `vagrant` user
2. SSH/Sharing enabled
3. Homebrew (used for a conceptual `brew version` test)
4. Have a hostname `vagrant-macos` (since mDNS seems to be the only way to connect to it nicely)

# Changes
- feat(vagrantfile_examples/macOS): add example Vagrantfile for Apple Virtualization using VirtioFS and mDNS SSH
- feat(test/acceptance/macos): add acceptance Vagrantfile and shell script to test macOS Apple Virtualization VMs with VirtioFS
- feat(lib/vagrant_utm/config): add skip_directory_share_mode config to disable QEMU directory share mode for Apple Virtualization
- feat(lib/vagrant_utm/synced_folder): skip folder auto-setup for Apple VMs; prompt manual VirtioFS config via UTM GUI
- feat(lib/vagrant_utm/action): add PromptVirtioFS action to warn users to manually configure shared folders in UTM GUI for Apple VMs
- fix(lib/vagrant_utm/driver/version_4_5): handle unsupported ip-address command error gracefully for Apple Virtualization VMs
- fix(lib/vagrant_utm/driver/version_4_6): add missing -l JavaScript argument to osascript calls for shared folder commands
- chore(Gemfile): add vagrant-spec gem for acceptance testing
- chore(Rakefile): add test tasks with unit and acceptance specs including macOS tests
- test(test/acceptance/provider/macos_spec): add acceptance tests verifying VM boot, SSH, Homebrew, and synced folder functionality on macOS Apple Virtualization VMs
- docs(vagrantfile_examples/macOS/README.md): add comprehensive instructions for creating and using macOS Vagrant boxes with UTM Apple Virtualization provider, including manual VirtioFS folder setup and troubleshooting tips

# Testing
## Run Test & Get the Shared Dir Path
```
$ vagrant plugin uninstall vagrant_utm; gem build vagrant_utm.gemspec && vagrant plugin install ./vagrant_utm-*.gem &&  rake test:macos

Uninstalling the 'vagrant_utm' plugin...
Successfully uninstalled vagrant_utm-0.1.5
WARNING:  lib/vagrant_utm/action/prompt_virtiofs.rb is not world-readable
WARNING:  vagrantfile_examples/macOS/README.md is not world-readable
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: vagrant_utm
  Version: 0.1.5
  File: vagrant_utm-0.1.5.gem
Installing the './vagrant_utm-0.1.5.gem' plugin. This can take a few minutes...
Installed the plugin 'vagrant_utm (0.1.5)'!
test/acceptance/macos/run.sh
==> Starting VM...
Bringing machine 'default' up with 'utm' provider...
==> default: Importing base box 'macOS26'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: macos_default_1769251116938_28779
==> default: Forwarding ports...
==> default: Running 'pre-boot' VM customizations...
==> default:
==> default: ======================================================================
==> default:   MANUAL STEP REQUIRED: VirtioFS Shared Folders
==> default: ======================================================================
==> default:
==> default: Apple Virtualization VMs require manual shared folder setup.
==> default: macOS security restrictions prevent automated configuration.
==> default:
==> default: Please complete these steps in UTM:
==> default:
==> default:   1. Open UTM application
==> default:   2. Right-click 'default' -> Edit
==> default:   3. Go to 'Sharing' tab
==> default:   4. Remove existing entries (if any), then re-add these paths:
==> default:
==> default:      -> /Users/dmitry/dev/dimmkirr/vagrant_utm/test/acceptance/macos
==> default:         (mounts at: /Volumes/My Shared Files/macos/)
==> default:
==> default:   5. Save the VM settings
==> default:
==> default: ======================================================================
==> default:
    default: Press ENTER when done to continue booting the VM...
```

At this point vagrant pauses and waits for our manual intervention

## Manually Configure Shared Dir
<img width="871" height="492" alt="image" src="https://github.com/user-attachments/assets/a03ba099-8c4b-4739-a026-c2ee0a2bc23e" />
<img width="824" height="456" alt="image" src="https://github.com/user-attachments/assets/0b4d62b5-0178-4578-869d-902489ed0db5" />
<img width="838" height="421" alt="image" src="https://github.com/user-attachments/assets/665f4ccf-4835-4118-81dd-f144dd180d9e" />

### Press Enter 
```
    default: Press ENTER when done to continue booting the VM...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: vagrant-macos.local:22
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: VirtioFS shared folders auto-mount at /Volumes/My Shared Files/
==> default: Running provisioner: shell...
    default: Running: inline script
==> Verifying SSH...
Darwin vagrant-macos.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:18 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_VMAPPLE arm64
==> Verifying Homebrew...
Homebrew 5.0.9
==> Verifying symlinked path...
==> Verifying bidirectional sync...
==> ALL TESTS PASSED
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...
```
