### PR TITLE
Allow shared folders with whitespace in path

### DIFF
--- a/lib/vagrant_utm/scripts/add_folder_share.applescript
+++ b/lib/vagrant_utm/scripts/add_folder_share.applescript
@@ -8,7 +8,7 @@
 on createQemuArgsForDir(dirId, dirPath)
 
     -- Prepare the QEMU argument strings
-    set fsdevArgStr to "-fsdev local,id=" & dirId & ",path=" & dirPath & ",security_model=mapped-xattr" 
+    set fsdevArgStr to "-fsdev \"local,id=" & dirId & ",path=" & dirPath & ",security_model=mapped-xattr\"" 
     set deviceArgStr to "-device virtio-9p-pci,fsdev=" & dirId & ",mount_tag=" & dirId
 
     return {fsdevArgStr, deviceArgStr}


### PR DESCRIPTION
Paths with whitespace cannot be added to shared folders because the path is not properly quoted.