### PR TITLE
fix: remove AppleScript line continuation characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Fix AppleScript line continuation character encoding issue on Japanese/Korean locales
+
 ## [0.1.5] - 2025-11-16
 
 - Support vm icon

--- a/lib/vagrant_utm/scripts/add_port_forwards.applescript
+++ b/lib/vagrant_utm/scripts/add_port_forwards.applescript
@@ -25,11 +25,12 @@ on run argv
     set ruleComponents to text items of ruleArg
     
     -- Create a port forwarding rule record
-    set portForwardRule to { Â
-          indexVal:indexNumber, protocolVal:item 1 of ruleComponents, Â
-          guestAddress:item 2 of ruleComponents, guestPort:item 3 of ruleComponents, Â
-          hostAddress:item 4 of ruleComponents, hostPort:item 5 of ruleComponents Â
-        }
+    set ruleProtocol to item 1 of ruleComponents
+    set ruleGuestAddress to item 2 of ruleComponents
+    set ruleGuestPort to item 3 of ruleComponents
+    set ruleHostAddress to item 4 of ruleComponents
+    set ruleHostPort to item 5 of ruleComponents
+    set portForwardRule to {indexVal:indexNumber, protocolVal:ruleProtocol, guestAddress:ruleGuestAddress, guestPort:ruleGuestPort, hostAddress:ruleHostAddress, hostPort:ruleHostPort}
     
     -- Add the rule to the list
     set end of portForwardRules to portForwardRule
@@ -49,13 +50,12 @@ on run argv
           set portForwards to port forwards of anInterface
           
           -- Create a new port forward configuration
-          set newPortForward to { Â
-                protocol:(protocolVal of portForwardRule), Â
-                guest address:(guestAddress of portForwardRule), Â 
-                guest port:(guestPort of portForwardRule), Â
-                host address:(hostAddress of portForwardRule), Â
-                host port:(hostPort of portForwardRule) Â
-              }
+          set forwardProtocol to protocolVal of portForwardRule
+          set forwardGuestAddress to guestAddress of portForwardRule
+          set forwardGuestPort to guestPort of portForwardRule
+          set forwardHostAddress to hostAddress of portForwardRule
+          set forwardHostPort to hostPort of portForwardRule
+          set newPortForward to {protocol:forwardProtocol, guest address:forwardGuestAddress, guest port:forwardGuestPort, host address:forwardHostAddress, host port:forwardHostPort}
           
           -- Add new port forward to the list
           copy newPortForward to the end of portForwards

--- a/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
+++ b/lib/vagrant_utm/scripts/read_forwarded_ports.applescript
@@ -17,9 +17,10 @@ on run argv
                     set i to i + 1
                     # Log the port forward details Virtualbox style 
                     # 'Forwarding(nicIndex)(ruleIndex)="protocol,guestAddress,guestPort,hostAddress,hostPort"'
-                    log "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & "," Â
-                        & guest address of aPortForward & "," & guest port of aPortForward & "," Â
-                        & host address of aPortForward & "," & host port of aPortForward & "\""
+                    set forwardingLine to "Forwarding(" & index of anInterface & ")(" & i & ")=\"" & protocol of aPortForward & ","
+                    set forwardingLine to forwardingLine & guest address of aPortForward & "," & guest port of aPortForward & ","
+                    set forwardingLine to forwardingLine & host address of aPortForward & "," & host port of aPortForward & "\""
+                    log forwardingLine
                 end repeat
             end if
         end repeat


### PR DESCRIPTION
## Summary

- Replace multi-line record literals (using `¬` continuation bytes) in `add_port_forwards.applescript` with local variable assignments followed by a single-line record.
- Replace the multi-line `log` statement in `read_forwarded_ports.applescript` with an intermediate `forwardingLine` variable.
- Both scripts are now plain ASCII and carry no locale-dependent bytes.

## Background

The single-byte `c2` (Mac OS Roman `¬`) used as the AppleScript line-continuation character works on US English systems where Mac OS Roman is the default encoding. On Japanese and Korean systems it is not recognised, causing a runtime error at `vagrant up` (issue #18).

PR #29 by @ynishinaka proposed switching to the 2-byte UTF-8 sequence `c2 ac`. This PR takes a different approach: remove the continuation characters entirely. Because AppleScript continuation is purely cosmetic (it splits one statement across physical lines), rewriting the statements without it produces identical behaviour while keeping the scripts encoding-agnostic.

## Test plan

- [ ] Verify `file lib/vagrant_utm/scripts/*.applescript` reports `ASCII text` for both changed files
- [ ] `vagrant up` on a Japanese/Korean locale system completes without encoding error