### PR TITLE
feat: add support for UTM 5.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- Driver: Add support for UTM 5.0.x
+
 ### Fixed
 - Fix AppleScript line continuation character encoding issue on Japanese/Korean locales
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ allowing Vagrant to control and provision machines via UTM's API.
 
 [UTM] is a free, full-featured system emulator and virtual machine host for iOS and macOS.  
 The UTM provider currently supports UTM versions 
+* 5.0.x
 * 4.7.x
 * 4.6.x   
 * 4.5.x (Obsolete, use plugin version 0.0.1)  

--- a/lib/vagrant_utm.rb
+++ b/lib/vagrant_utm.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       autoload :Version_4_5, lib_path.join("version_4_5") # rubocop:disable Naming/VariableNumber
       autoload :Version_4_6, lib_path.join("version_4_6") # rubocop:disable Naming/VariableNumber
       autoload :Version_4_7, lib_path.join("version_4_7") # rubocop:disable Naming/VariableNumber
+      autoload :Version_5_0, lib_path.join("version_5_0") # rubocop:disable Naming/VariableNumber
     end
 
     # Drop some autoloads for the model classes

--- a/lib/vagrant_utm/driver/meta.rb
+++ b/lib/vagrant_utm/driver/meta.rb
@@ -56,7 +56,8 @@ module VagrantPlugins
           @logger.debug("Finding driver for UTM version: #{@version}")
           driver_map = {
             "4.6" => Version_4_6,
-            "4.7" => Version_4_7
+            "4.7" => Version_4_7,
+            "5.0" => Version_5_0
           }
 
           # UTM version < 4.6.5  doesn't have

--- a/lib/vagrant_utm/driver/version_5_0.rb
+++ b/lib/vagrant_utm/driver/version_5_0.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require File.expand_path("version_4_7", __dir__)
+
+module VagrantPlugins
+  module Utm
+    module Driver
+      # Driver for UTM 5.0.x
+      class Version_5_0 < Version_4_7 # rubocop:disable Naming/ClassAndModuleCamelCase
+        def initialize(uuid)
+          super
+
+          @logger = Log4r::Logger.new("vagrant::provider::utm::version_5_0")
+        end
+      end
+    end
+  end
+end

--- a/spec/vagrant_plugins/utm/driver/version_5_0_spec.rb
+++ b/spec/vagrant_plugins/utm/driver/version_5_0_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+RSpec.describe VagrantPlugins::Utm::Driver::Version_5_0 do
+  include_context "utm"
+  let(:utm_version) { "5.0.3" }
+  subject { VagrantPlugins::Utm::Driver::Meta.new(uuid) }
+
+  it_behaves_like "a version 4.x utm driver"
+end


### PR DESCRIPTION
Fixes #47

## What

Adds a `Version_5_0` driver so the plugin accepts UTM 5.0.x instead of failing the provider usability check with:

```
utm_vagrant has detected that you have a version of UTM installed
that is not supported by this version of utm_vagrant.
...
4.6, 4.7
```

## Why this is safe

UTM 5.0's scripting dictionary (`/Applications/UTM.app/Contents/Resources/UTM.sdef`) retains the full AppleScript interface this plugin drives — import/export, directory shares, port forwards, network interfaces, QEMU additional arguments, `update configuration` — so `Version_5_0` subclasses `Version_4_7` unchanged; only the driver map and autoload needed new entries. This mirrors how 4.7 support was added in #35.

Same situation exists in packer-plugin-utm, fixed the same way: naveenrajm7/packer-plugin-utm#50.

## Changes

- `lib/vagrant_utm/driver/version_5_0.rb` — new driver, subclasses `Version_4_7`
- `lib/vagrant_utm/driver/meta.rb` — `"5.0"` entry in `driver_map`
- `lib/vagrant_utm.rb` — autoload for `Version_5_0`
- `spec/vagrant_plugins/utm/driver/version_5_0_spec.rb` — driver spec (shared 4.x examples, version `5.0.3`)
- `docs/index.md`, `CHANGELOG.md` — supported versions

## Testing

- `rspec spec/vagrant_plugins/utm/driver/` — passes, including the new `Version_5_0` spec exercising `Driver::Meta` version selection with `5.0.3`
- `rubocop` on changed files — no offenses
- End-to-end on macOS 26.5 (Apple Silicon) with UTM 5.0.3: built the gem from this branch, `vagrant plugin install ./vagrant_utm-0.1.5.gem`, then `vagrant up --provider utm` imports and boots a Debian 13 arm64 box, SSH key rotation works, and the shell provisioner runs to completion.
- One transient `Connection is invalid. (-609)` from `read_forwarded_ports.applescript` was observed on the first run (the flake #36 added retries for at boot; this call site isn't covered by that retry). It cleared on re-run and also occurs on 4.x — unrelated to 5.0 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
